### PR TITLE
add requirements.txt for easier dependency installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The program can be run manually, but scheduling it to run frequently will ensure
 
 REQUIREMENTS:
 
-gkeepapi, pandas
+Just run `pip install -r requirements.txt` and let Python do its thing.
+
+~~gkeepapi, pandas~~
 
 Note -- gkeepapi is unofficial, and is not supported by Google. https://github.com/kiwiz/gkeepapi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# install these via singular `pip install -r requirements.txt` (`pip install --help` for more information)
+# to get their versions, I simply `pip install`-ed them and then `pip freeze | Select-String -Pattern <PACKAGE NAME>` to find their currently installed versions
+google-api-python-client==1.12.8
+google-auth-httplib2==0.0.4
+google-auth-oauthlib==0.4.2
+gkeepapi==0.13.4
+pandas==1.2.2


### PR DESCRIPTION
adding the requirements into a file with their current versions will prevent pain in the future.

install instructions included in the requirements and README